### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/auto-assign.yml
+++ b/.github/workflows/auto-assign.yml
@@ -1,4 +1,7 @@
 name: 'Auto Assign'
+permissions:
+  contents: read
+  pull-requests: write
 on:
   pull_request_target:
     types: [opened, ready_for_review]


### PR DESCRIPTION
Potential fix for [https://github.com/whartondylan/starter-workflows/security/code-scanning/4](https://github.com/whartondylan/starter-workflows/security/code-scanning/4)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will specify the minimal permissions required for the `auto-assign-action` to function. Based on the action's purpose (assigning reviewers and assignees to pull requests), it likely requires `contents: read` and `pull-requests: write`. These permissions will be explicitly defined to ensure the workflow operates securely.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
