### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/auto-assign-issues.yml
+++ b/.github/workflows/auto-assign-issues.yml
@@ -1,5 +1,9 @@
 name: Issue assignment
 
+permissions:
+    contents: read
+    issues: write
+
 on:
     issues:
         types: [opened]


### PR DESCRIPTION
Potential fix for [https://github.com/whartondylan/starter-workflows/security/code-scanning/5](https://github.com/whartondylan/starter-workflows/security/code-scanning/5)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will specify the minimal permissions required for the workflow to function correctly. Since the workflow is designed to auto-assign issues, it only needs `contents: read` and `issues: write` permissions. These permissions will ensure that the workflow can read repository contents and modify issue assignments without granting unnecessary access to other resources.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
