### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -5,6 +5,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
 
   pre-commit:


### PR DESCRIPTION
Potential fix for [https://github.com/whartondylan/starter-workflows/security/code-scanning/3](https://github.com/whartondylan/starter-workflows/security/code-scanning/3)

To fix the issue, add a `permissions` block to the workflow. Since the workflow only requires read access to repository contents (e.g., to check out code), the permissions should be set to `contents: read`. This ensures that the GITHUB_TOKEN has the minimal permissions required for the job.

The `permissions` block should be added at the root level of the workflow, so it applies to all jobs in the workflow. This avoids redundancy and ensures consistency across jobs.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
